### PR TITLE
fix: foldLine escape character logic

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -117,12 +117,15 @@ export function foldLine (str, maxLen = 76) {
   let match;
 
   while (pos < len) {
+    let escaped = false;
+
     curLine = str.substring(pos, pos + maxLen);
 
     // ensure that the line never ends with a partial escaping
     // make longer lines if needed
-    while (curLine.endsWith('\\') && pos + curLine.length < len) {
-      curLine += str.charAt(pos + curLine.length + 1); // Append the next character
+    if (curLine.endsWith('\\') && pos + curLine.length < len) {
+      escaped = true;
+      curLine += str.charAt(pos + curLine.length); // Append the next character
     }
 
     // ensure that if possible, line breaks are done at reasonable places
@@ -134,7 +137,7 @@ export function foldLine (str, maxLen = 76) {
       if ((match = /.*\s+/.exec(curLine)) && /\S/.test(match[0])) {
         // use everything before and including the last white space character (if anything)
         curLine = match[0];
-      } else if ((match = /.*[\x21-\x2f0-9\x5b-\x60\x7b-\x7e]+/.exec(curLine)) && /[^\x21-\x2f0-9\x5b-\x60\x7b-\x7e]/.test(match[0])) {
+      } else if (!escaped && (match = /.*[\x21-\x2f0-9\x5b-\x60\x7b-\x7e]+/.exec(curLine)) && /[^\x21-\x2f0-9\x5b-\x60\x7b-\x7e]/.test(match[0])) {
         // use everything before and including the last "special" character (if anything)
         curLine = match[0];
       }

--- a/test/shared.js
+++ b/test/shared.js
@@ -90,12 +90,38 @@ X-Poedit-SourceCharset: UTF-8`;
     });
 
     it('should fold the line into multiple lines with the right length', () => {
-      const line = Array.from({ length: 75 }, () => 'a').join('') + '\\aaaaa\\aaaa';
+      const line = Array.from({ length: 76 }, () => 'a').join('') + 'aaaaa\\aaaa';
       const folded = foldLine(line);
       expect(folded.length).to.equal(2);
+      expect(folded[0].length).to.equal(76);
       expect(line).to.equal(folded.join(''));
       expect(folded).to.deep.equal([
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\',
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'aaaaa\\aaaa'
+      ]);
+    });
+
+    it('should fold the line into multiple lines with the right length (escaped character)', () => {
+      const line = Array.from({ length: 75 }, () => 'a').join('') + '\\aaaaaa\\aaaa';
+      const folded = foldLine(line);
+      expect(folded.length).to.equal(2);
+      expect(folded[0].length).to.equal(77);
+      expect(line).to.equal(folded.join(''));
+      expect(folded).to.deep.equal([
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\a',
+        'aaaaa\\aaaa'
+      ]);
+    });
+
+
+    it('should fold the line into multiple lines with the right length (escaped forward slash)', () => {
+      const line = Array.from({ length: 75 }, () => 'a').join('') + '\\\\aaaaa\\aaaa';
+      const folded = foldLine(line);
+      expect(folded.length).to.equal(2);
+      expect(folded[0].length).to.equal(77);
+      expect(line).to.equal(folded.join(''));
+      expect(folded).to.deep.equal([
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\\\',
         'aaaaa\\aaaa'
       ]);
     });


### PR DESCRIPTION
The escape character logic was not working correctly.

The logic of how a line is folded with a final escape character was flawed. Using a loop to consume back slashes would not allow for an escaped back slash to be folded correctly, it would append an extra character to the line.

- Use if statements to check for escape characters. Only one extra character should be appended to the line, and it should be considered escaped.
- Add new test cases to test the escape character logic.